### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/bin/analysis_submission.py
+++ b/bin/analysis_submission.py
@@ -301,8 +301,7 @@ class upload_and_submit:
             attempts = 0
             command, out = self.submission(attempts)
             print("-" * 100)
-            print("CURL submission command: \n")
-            print(self._sanitize_for_logging(command))
+            print("CURL submission command: [redacted]")
             print("Returned output: [redacted]")
             print("Returned output length (bytes): {}".format(len(out) if out is not None else 0))
             print("-" * 100)

--- a/bin/analysis_submission.py
+++ b/bin/analysis_submission.py
@@ -303,8 +303,8 @@ class upload_and_submit:
             print("-" * 100)
             print("CURL submission command: \n")
             print(self._sanitize_for_logging(command))
-            print("Returned output: \n")
-            print(self._sanitize_for_logging(out))
+            print("Returned output: [redacted]")
+            print("Returned output length (bytes): {}".format(len(out) if out is not None else 0))
             print("-" * 100)
         else:
             print("File upload errors detected, aborted file upload:\n {}".format(errors))

--- a/bin/analysis_submission.py
+++ b/bin/analysis_submission.py
@@ -117,6 +117,27 @@ class upload_and_submit:
         self.api_service = api_service
         self.test = test
 
+    def _sanitize_for_logging(self, value):
+        """
+        Redact sensitive credentials from text before logging.
+        :param value: bytes or string to sanitize
+        :return: Sanitized string safe for logs
+        """
+        if isinstance(value, bytes):
+            text = value.decode(errors='replace')
+        else:
+            text = str(value)
+
+        if self.analysis_password:
+            text = text.replace(self.analysis_password, '***REDACTED***')
+
+        # Mask common curl basic-auth token in command strings: -u username:password
+        text = text.replace('-u {}:'.format(self.analysis_username), '-u {}:***REDACTED***'.format(self.analysis_username))
+        # Mask potential URL-style credentials: username:password@
+        text = text.replace('{}:@'.format(self.analysis_username), '{}:***REDACTED***@'.format(self.analysis_username))
+
+        return text
+
     def upload_to_ENA(self, trialcount):
         """
         Upload data file(s) to ENA
@@ -281,9 +302,9 @@ class upload_and_submit:
             command, out = self.submission(attempts)
             print("-" * 100)
             print("CURL submission command: \n")
-            print(command)
+            print(self._sanitize_for_logging(command))
             print("Returned output: \n")
-            print(out.decode())
+            print(self._sanitize_for_logging(out))
             print("-" * 100)
         else:
             print("File upload errors detected, aborted file upload:\n {}".format(errors))


### PR DESCRIPTION
Potential fix for [https://github.com/enasequence/ena-analysis-submitter/security/code-scanning/4](https://github.com/enasequence/ena-analysis-submitter/security/code-scanning/4)

General fix: never log raw data that may contain secrets. Before printing command/output text, redact sensitive fields (at minimum the known password and credential patterns like `-u user:pass`) and then log only sanitized values.

Best minimal fix in `bin/analysis_submission.py`:
1. Add a helper method in `upload_and_submit` to sanitize log text by:
   - decoding bytes safely,
   - replacing the exact password value with a mask,
   - masking common curl basic-auth forms (`-u user:pass`, and URL `user:pass@` patterns).
2. In `submit_data()`, replace `print(out.decode())` with printing sanitized output via this helper.
3. Also sanitize `command` before printing, since it currently includes raw credentials and is an adjacent clear-text secret exposure.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
