### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/bin/analysis_submission.py
+++ b/bin/analysis_submission.py
@@ -153,8 +153,8 @@ class upload_and_submit:
             md5downloaded = "curl -s ftp://webin.ebi.ac.uk/{} --user {}:{} | md5sum | cut -f1 -d ' '".format(os.path.basename(file.get('name')), self.analysis_username, self.analysis_password)       # Command to check the MD5 value for the submitted file
             md5uploaded = file.get('md5_value')         # The MD5 calculated before the file upload
             print('-' * 100)
-            print("CURL command:\n{}".format(self._sanitize_for_logging(command)))
-            print("MD5 Download command:\n{}".format(self._sanitize_for_logging(md5downloaded)))
+            print("Upload operation prepared for file: {}".format(os.path.basename(file.get('name'))))
+            print("MD5 verification operation prepared for file: {}".format(os.path.basename(file.get('name'))))
             print("MD5 uploaded:\n{}".format(md5uploaded))
             print('-' * 100)
 

--- a/bin/analysis_submission.py
+++ b/bin/analysis_submission.py
@@ -153,8 +153,8 @@ class upload_and_submit:
             md5downloaded = "curl -s ftp://webin.ebi.ac.uk/{} --user {}:{} | md5sum | cut -f1 -d ' '".format(os.path.basename(file.get('name')), self.analysis_username, self.analysis_password)       # Command to check the MD5 value for the submitted file
             md5uploaded = file.get('md5_value')         # The MD5 calculated before the file upload
             print('-' * 100)
-            print("CURL command:\n{}".format(command))
-            print("MD5 Download command:\n{}".format(md5downloaded))
+            print("CURL command:\n{}".format(self._sanitize_for_logging(command)))
+            print("MD5 Download command:\n{}".format(self._sanitize_for_logging(md5downloaded)))
             print("MD5 uploaded:\n{}".format(md5uploaded))
             print('-' * 100)
 


### PR DESCRIPTION
Potential fix for [https://github.com/enasequence/ena-analysis-submitter/security/code-scanning/2](https://github.com/enasequence/ena-analysis-submitter/security/code-scanning/2)

General fix: never log raw command strings or outputs that may embed credentials. Either avoid logging them or pass them through a credential-redaction sanitizer before printing.

Best fix here (without changing functionality): in `bin/analysis_submission.py`, inside `upload_to_ENA`, keep command execution unchanged, but sanitize values at logging time using the already-defined `_sanitize_for_logging` helper. Replace the direct prints of `command` and `md5downloaded` with sanitized versions. This addresses all variants tied to password taint reaching line 157 (and also hardens line 156).

No new dependency is required. No behavioral change to upload/submission logic—only safer log output.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
